### PR TITLE
fixed to create directory for outputfile

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -69,6 +69,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/$ENV{PROJECT_NAME}.di
 # Caffe Tools
 #
 add_executable(caffe2demitasse
+  create_dirs.cpp
   caffe2demitasse.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/$ENV{PROJECT_NAME}.dir/caffe.pb.cc
   network_model_generated.h
@@ -104,6 +105,7 @@ if (Matlab_FOUND)
   link_directories(${Matlab_LIBRARY_DIRS})
 
   add_executable(matconvnet2demitasse
+    create_dirs.cpp
     matconvnet2demitasse.cpp
     network_model_generated.h
   )

--- a/tools/create_dirs.cpp
+++ b/tools/create_dirs.cpp
@@ -1,0 +1,79 @@
+/*
+Copyright (C) 2017 Denso IT Laboratory, Inc.
+All Rights Reserved
+
+Denso IT Laboratory, Inc. retains sole and exclusive ownership of all
+intellectual property rights including copyrights and patents related to this
+Software.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of the Software and accompanying documentation to use, copy, modify, merge,
+publish, or distribute the Software or software derived from it for
+non-commercial purposes, such as academic study, education and personal use,
+subject to the following conditions:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <libgen.h>
+#include <sys/stat.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+#include "create_dirs.h"
+
+int create_dirs(const char* path) {
+
+  char *tmp_path = (char *)malloc(sizeof(char) * (strlen(path) + 1));
+  if (tmp_path == NULL) {
+    return -1; // mem error
+  }
+  strcpy(tmp_path, path);
+    
+  char *dir_name = dirname(tmp_path);
+  if (strcmp(dir_name, ".") == 0 || strcmp(dir_name, "/") == 0) {
+    free(tmp_path);
+    return 0;
+  }
+
+  for (char *p = dir_name + 1; *p; p++) {
+    if (*p == '/') {
+      *p = '\0';
+      if (mkdir(dir_name, S_IRWXU) != 0) {
+        if (errno != EEXIST) {
+          free(tmp_path);
+          return -1;
+        }
+      }
+      *p = '/';
+    }
+  }
+
+  if (mkdir(dir_name, S_IRWXU) != 0) {
+    if (errno != EEXIST) {
+      free(tmp_path);
+      return -1;
+    }
+  }
+
+  free(tmp_path);
+  return 0;
+}

--- a/tools/create_dirs.h
+++ b/tools/create_dirs.h
@@ -1,0 +1,39 @@
+/*
+Copyright (C) 2017 Denso IT Laboratory, Inc.
+All Rights Reserved
+
+Denso IT Laboratory, Inc. retains sole and exclusive ownership of all
+intellectual property rights including copyrights and patents related to this
+Software.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of the Software and accompanying documentation to use, copy, modify, merge,
+publish, or distribute the Software or software derived from it for
+non-commercial purposes, such as academic study, education and personal use,
+subject to the following conditions:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+ */
+
+extern "C" {
+
+int create_dirs(const char* path);
+
+}

--- a/tools/matconvnet2demitasse.cpp
+++ b/tools/matconvnet2demitasse.cpp
@@ -34,16 +34,15 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <math.h>
 
 #include <fstream>
-
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <libgen.h>
+#include <iostream>
 
 #include "mat.h"
 #include "matrix.h"
 
 #include "flatbuffers/flatbuffers.h"
 #include "network_model_generated.h"
+
+#include "create_dirs.h"
 
 using DataInputForm = struct {
         int w; // width
@@ -838,8 +837,12 @@ void write_model_to_file(flatbuffers::FlatBufferBuilder& builder, const std::str
 
   std::ofstream fs(file, std::ios::out | std::ios::binary | std::ios::trunc);
 
-  fs.write((const char*)buffer, size);
-  fs.close();
+  if (fs.is_open()) {
+    fs.write((const char*)buffer, size);
+    fs.close();
+  } else {
+    std::cerr << "Failed to open file :" << errno << std::endl;
+  }
 
   builder.ReleaseBufferPointer();
 }
@@ -928,13 +931,6 @@ void load_matconvnet_model(const std::string& model, const std::string& outfile)
   write_model_to_file(builder, outfile);
 }
 
-void create_dirs(const char* path) {
-  const char *dir_name = dirname((char *)path);
-
-  if (strcmp(dir_name, ".") != 0 && strcmp(dir_name, "/") != 0) {
-    mkdir(dir_name, 0777);
-  }
-}
 
 int main(int argc, char** argv) {
   if (argc < 2) {


### PR DESCRIPTION
Fixed convert tools to handle output file path which includes directories.
create_dirs() create directories if those are not exist.